### PR TITLE
enable automation and update docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ commands:
             source $BASH_ENV
             source $HOME/venv/bin/activate
             touch $HOME/.trident/hm2012_lr.h5
+            git submodule update --init
             cd doc/source
             python -m sphinx -M html "." "_build" -W
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
       - checkout
       - set-env
       - install-dependencies:
-          yttag: "None"
+          yttag: "YT_HEAD"
       - configure-trident
       - build-docs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v7
+          key: python-<< parameters.tag >>-dependencies-v8
 
       - install-dependencies:
           yttag: << parameters.yttag >>
@@ -212,7 +212,7 @@ jobs:
 
       - save_cache:
           name: "Save dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v7
+          key: python-<< parameters.tag >>-dependencies-v8
           paths:
             - ~/.cache/pip
             - ~/venv
@@ -272,14 +272,14 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v7
+          key: python-<< parameters.tag >>-dependencies-v8
       - set-env
       - install-dependencies:
           yttag: "YT_HEAD"
       - configure-trident
       - save_cache:
           name: "Save dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v7
+          key: python-<< parameters.tag >>-dependencies-v8
           paths:
             - ~/.cache/pip
             - ~/venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
             echo 'TRIDENT_ION_DATA=$HOME/.trident' >> $BASH_ENV
             echo 'TRIDENT_ANSWER_DATA=$HOME/answer_test_data' >> $BASH_ENV
             echo 'TRIDENT_CONFIG=$HOME/.trident/config.tri' >> $BASH_ENV
-            echo 'YT_GOLD=d218647162201673e8d0bc513a16b1b3add02a47' >> $BASH_ENV
+            echo 'YT_GOLD=master' >> $BASH_ENV
             echo 'YT_HEAD=master' >> $BASH_ENV
             echo 'TRIDENT_GOLD=test-standard-v7' >> $BASH_ENV
             echo 'TRIDENT_HEAD=tip' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v6
+          key: python-<< parameters.tag >>-dependencies-v7
 
       - install-dependencies:
           yttag: << parameters.yttag >>
@@ -211,11 +211,12 @@ jobs:
 
       - save_cache:
           name: "Save dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v6
+          key: python-<< parameters.tag >>-dependencies-v7
           paths:
             - ~/.cache/pip
             - ~/venv
             - ~/yt-git
+            - ~/yt_astro_analysis
 
       - lint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,16 @@ commands:
                 pip install -e .
                 popd
             fi
+            # install yt-astro-analysis from source
+            if [ ! -f $HOME/yt_astro_analysis/README.md ]; then
+                git clone --branch=master https://github.com/yt-project/yt_astro_analysis $HOME/yt_astro_analysis
+            fi
+            pushd $HOME/yt_astro_analysis
+            # return to tip before pulling
+            git checkout master
+            git pull origin master
+            pip install -e .
+            popd
             pip install -e .[dev]
 
   install-trident:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,10 +274,6 @@ workflows:
            tag: "3.6.11"
 
        - tests:
-           name: "Python 3.7 tests with yt gold"
-           tag: "3.7.8"
-
-       - tests:
            name: "Python 3.8 tests with yt gold"
            tag: "3.8.5"
 
@@ -291,15 +287,19 @@ workflows:
            name: "Test docs build"
            tag: "3.8.5"
 
-   daily:
+   weekly:
      triggers:
        - schedule:
-           cron: "0 0 * * *"
+           cron: "0 0 * * 1"
            filters:
             branches:
               only:
                 - master
      jobs:
+       - tests:
+           name: "Python 3.7 tests with yt gold"
+           tag: "3.7.8"
+
        - tests:
            name: "Python 3.8 tests with yt tip"
            tag: "3.8.5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
             echo 'TRIDENT_CONFIG=$HOME/.trident/config.tri' >> $BASH_ENV
             echo 'YT_GOLD=master' >> $BASH_ENV
             echo 'YT_HEAD=master' >> $BASH_ENV
-            echo 'TRIDENT_GOLD=test-standard-v7' >> $BASH_ENV
+            echo 'TRIDENT_GOLD=tip' >> $BASH_ENV
             echo 'TRIDENT_HEAD=tip' >> $BASH_ENV
 
   install-dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,10 +269,21 @@ jobs:
 
     steps:
       - checkout
+      - restore_cache:
+          name: "Restore dependencies cache."
+          key: python-<< parameters.tag >>-dependencies-v7
       - set-env
       - install-dependencies:
           yttag: "YT_HEAD"
       - configure-trident
+      - save_cache:
+          name: "Save dependencies cache."
+          key: python-<< parameters.tag >>-dependencies-v7
+          paths:
+            - ~/.cache/pip
+            - ~/venv
+            - ~/yt-git
+            - ~/yt_astro_analysis
       - build-docs
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ commands:
             fi
             if [ << parameters.coverage >> == 1 ]; then
                 # code coverage report
-                export COVERALLS_REPO_TOKEN="yUoFnf5H5uC9MJ9kLqzKaoSxkPf5dHc7F"
+                export COVERALLS_REPO_TOKEN="YqKi9UvAZbuZEO7mgaxBAH9ripJSnfQJ7"
                 coveralls
             fi
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Trident
 
-[![CircleCI](https://circleci.com/gh/trident-project/trident/tree/master.svg?style=svg)](https://circleci.com/gh/trident-project/trident/tree/master)
-[![Coverage Status](https://coveralls.io/repos/github/trident-project/trident/badge.svg?branch=master)](https://coveralls.io/github/trident-project/trident?branch=master)
-[![Documentation Status](https://readthedocs.org/projects/trident/badge/?version=latest)](http://trident.readthedocs.io/en/latest/?badge=latest)
-[![PyPI version](https://badge.fury.io/py/trident.svg)](https://badge.fury.io/py/trident)
+[![CircleCI](https://circleci.com/gh/foggie-sims/trident/tree/master.svg?style=svg)](https://circleci.com/gh/foggie-sims/trident/tree/master)
+[![Coverage Status](https://coveralls.io/repos/github/foggie-sims/trident/badge.svg?branch=master)](https://coveralls.io/github/foggie-sims/trident?branch=master)
+[![Documentation Status](https://readthedocs.org/projects/foggie-trident/badge/?version=latest)](https://foggie-trident.readthedocs.io/en/latest/?badge=latest)
 
 Trident is a Python package for creating synthetic absorption-line spectra
 from astrophysical hydrodynamics simulations.  It utilizes the yt package
@@ -22,15 +21,11 @@ pip install trident
 To get the development version, clone this repository and install like this:
 
 ```
-git clone https://github.com/trident-project/trident
+git clone https://github.com/foggie-sims/trident
 cd trident
 pip install -e .
 ```
 
 ## Resources
 
- * The Trident project homepage: http://trident-project.org
-
- * Trident documentation: http://trident.readthedocs.org
-
- * For questions, comments, and announcements, please join our low-volume mailing list: https://groups.google.com/forum/#!forum/trident-project-users
+ * Trident documentation: http://foggie-trident.readthedocs.org

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ and follow the instructions there to issue your pull request.
 After your pull request has been issued, steps 2 and 3 can be repeated
 to add new changes until your pull request has been merged.
 
+### Don't do what Donnie Don't does
+
+The main branch of trident is called `master`. Try not to ever push
+changes on the master branch directly to the main repository (i.e.,
+`git push origin master`). This will add your changes for
+everyone. However, if done accidentally, don't worry, it can be
+undone.
+
 ## Resources
 
  * Documentation: http://foggie-trident.readthedocs.org

--- a/README.md
+++ b/README.md
@@ -4,28 +4,102 @@
 [![Coverage Status](https://coveralls.io/repos/github/foggie-sims/trident/badge.svg?branch=master)](https://coveralls.io/github/foggie-sims/trident?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/foggie-trident/badge/?version=latest)](https://foggie-trident.readthedocs.io/en/latest/?badge=latest)
 
+This is the official trident version of the FOGGIE project.
+
 Trident is a Python package for creating synthetic absorption-line spectra
 from astrophysical hydrodynamics simulations.  It utilizes the yt package
 to read in simulation datasets and extends it to provide realistic
 synthetic observations appropriate for studies of the interstellar,
 circumgalactic, and intergalactic media.
 
-## Installation (after yt installed)
+## Installation
 
-Trident can be installed with pip:
+This assumes that you already have some version of conda installed.
+FOGGIE-trident must be install from source and currently requires both
+`yt` and `yt_astro_analysis` to be installed from source. It is
+recommended to keep the three repository directories together in the
+same root directory.
 
+### 1. Install initial dependencies
 ```
-pip install trident
+conda install numpy cython mpi4py
 ```
 
-To get the development version, clone this repository and install like this:
-
+### 2. Install yt
 ```
-git clone https://github.com/foggie-sims/trident
-cd trident
+git clone https://github.com/yt-project/yt YOUR_CODE_DIR/yt
+cd YOUR_CODE_DIR/yt
 pip install -e .
 ```
 
+### 3. Install yt_astro_analysis
+```
+git clone https://github.com/yt-project/yt_astro_analysis YOUR_CODE_DIR/yt_astro_analysis
+cd YOUR_CODE_DIR/yt_astro_analysis
+pip install -e .
+```
+
+### 4. Install trident
+```
+git clone git@github.com:foggie-sims/trident YOUR_CODE_DIR/trident
+cd YOUR_CODE_DIR/trident
+pip install -e .
+```
+
+The above will not work if you do not have your ssh key on github
+or do not have write access to the FOGGIE-trident repo. If you
+don't think you'll need to do any development yourself, you can do
+this command to clone instead.
+```
+git clone https://github.com/foggie-sims/trident
+```
+
+### 5. Updating trident (or other source repositories)
+To pull in the latest changes to trident (or yt, yt_astro_analysis),
+do the following:
+```
+cd YOUR_CODE_DIR/trident
+git pull origin master
+```
+
+And you're done! Take the rest of the day off.
+
+## Configuring Trident
+
+Oh right, you want to use trident! Coming soon.
+
+## Development
+
+Trident development happens through pull requests. In a nutshell, you
+create your own branch, make changes, push them to the repo, and issue
+a pull request.
+
+### 1. Make a new branch
+You can name your branch whatever you want.
+```
+git checkout -b NEW_BRANCH_NAME
+```
+
+### 2. Make changes, commit them.
+Make whatever changes you want. Assuming you want to commit every
+altered file, do the following:
+```
+git commit -am 'A bunch of changes.'
+```
+Repeat as necessary.
+
+### 3. Push to the main repository
+```
+git push origin NEW_BRANCH_NAME
+```
+If this is the first time pushing the new branch, you will see a URL
+for opening a pull request. If not, go to the
+[main repo](https://github.com/foggie-sims/trident) in a web browser
+and follow the instructions there to issue your pull request.
+
+After your pull request has been issued, steps 2 and 3 can be repeated
+to add new changes until your pull request has been merged.
+
 ## Resources
 
- * Trident documentation: http://foggie-trident.readthedocs.org
+ * Documentation: http://foggie-trident.readthedocs.org

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -60,7 +59,7 @@ setup(
     install_requires=[
         'astropy',
         'h5py',
-        'matplotlib',
+        'matplotlib<3.3.0',
         'numpy!=1.14.0',
         'requests',
         'yt>=3.6.0',

--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -13,7 +13,7 @@ Unit test for the AbsorptionSpectrum analysis module
 
 import numpy as np
 import os
-from yt.convenience import load
+from yt.loaders import load
 from yt.testing import \
     assert_allclose_units, \
     assert_almost_equal

--- a/tests/test_absorption_spectrum_fit.py
+++ b/tests/test_absorption_spectrum_fit.py
@@ -11,7 +11,7 @@ Unit test for the AbsorptionSpectrum analysis module
 #-----------------------------------------------------------------------------
 
 import os
-from yt.convenience import load
+from yt.loaders import load
 
 from trident import \
     make_simple_ray, \

--- a/tests/test_auto_lambda.py
+++ b/tests/test_auto_lambda.py
@@ -11,7 +11,7 @@ tests for auto-lambda feature
 #-----------------------------------------------------------------------------
 
 import os
-from yt.convenience import load
+from yt.loaders import load
 from yt.testing import \
     assert_allclose
 

--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -13,7 +13,7 @@ Unit test for the light_ray analysis module
 
 import numpy as np
 
-from yt.convenience import \
+from yt.loaders import \
     load
 from yt.testing import \
     assert_array_equal, \

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -13,7 +13,7 @@ Tests to assure the code runs on example pipelines
 
 import h5py
 import os
-from yt.convenience import load
+from yt.loaders import load
 from yt.testing import \
     assert_almost_equal
 

--- a/tests/test_velocity_space.py
+++ b/tests/test_velocity_space.py
@@ -11,7 +11,7 @@ tests for velocity bin space
 #-----------------------------------------------------------------------------
 
 import os
-from yt.convenience import load
+from yt.loaders import load
 from yt.testing import \
     assert_allclose
 

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -21,7 +21,7 @@ from yt.data_objects.data_containers import \
     YTDataContainer
 from yt.data_objects.static_output import \
     Dataset
-from yt.convenience import load
+from yt.loaders import load
 from yt.funcs import get_pbar, mylog
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.on_demand_imports import _astropy

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from yt_astro_analysis.cosmological_observation.cosmology_splice import \
     CosmologySplice
-from yt.convenience import \
+from yt.loaders import \
     load
 from yt.frontends.ytdata.utilities import \
     save_as_dataset

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -13,7 +13,7 @@ SpectrumGenerator class and member functions.
 
 from trident.light_ray import \
     LightRay
-from yt.convenience import \
+from yt.loaders import \
     load
 from trident.config import \
     ion_table_filepath

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -16,7 +16,7 @@ import os
 
 from trident.absorption_spectrum.absorption_spectrum import \
     AbsorptionSpectrum
-from yt.convenience import \
+from yt.loaders import \
     load
 from yt.data_objects.data_containers import \
     YTDataContainer


### PR DESCRIPTION
This enables various automation (testing, coverage, etc) for foggie-trident.

See [here](https://github.com/brittonsmith/trident/tree/foginit) for a rendering of the README.

I'll keep this marked as a work in progress until the following things are done:

- [x] testing is working
- [x] README is updated with installation instructions