### PR TITLE
Fix sphinx error and remove on-demand imports

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -77,7 +77,7 @@ release = '1.3.dev1'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -14,7 +14,8 @@ AbsorptionSpectrum class and member functions.
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from yt.utilities.on_demand_imports import _h5py as h5py
+from astropy.io import fits as pyfits
+import h5py
 import numpy as np
 
 from yt.data_objects.data_containers import \
@@ -24,7 +25,6 @@ from yt.data_objects.static_output import \
 from yt.loaders import load
 from yt.funcs import get_pbar, mylog
 from yt.units.yt_array import YTArray, YTQuantity
-from yt.utilities.on_demand_imports import _astropy
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
     _get_comm, \
     parallel_objects, \
@@ -35,8 +35,6 @@ from yt.utilities.physical_constants import \
 
 from trident.absorption_spectrum.absorption_line import \
     tau_profile
-
-pyfits = _astropy.pyfits
 
 _bin_space_units = {'wavelength': 'angstrom',
                     'velocity': 'km/s'}

--- a/trident/absorption_spectrum/absorption_spectrum_fit.py
+++ b/trident/absorption_spectrum/absorption_spectrum_fit.py
@@ -1,5 +1,6 @@
-from yt.utilities.on_demand_imports import _h5py as h5py
+import h5py
 import numpy as np
+from scipy import optimize
 
 from trident.absorption_spectrum.absorption_line import \
     voigt
@@ -7,10 +8,6 @@ from yt.funcs import \
     mylog
 from yt.units.yt_array import \
     YTArray
-from yt.utilities.on_demand_imports import \
-    _scipy
-
-optimize = _scipy.optimize
 
 def generate_total_fit(x, fluxData, orderFits, speciesDicts,
         minError=1E-4, complexLim=.995,

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -11,6 +11,9 @@ SpectrumGenerator class and member functions.
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from astropy.convolution import convolve
+from astropy.io import fits as pyfits
+import h5py
 import numpy as np
 import os
 
@@ -45,9 +48,6 @@ from trident.plotting import \
     plot_spectrum
 from trident.config import \
     trident_path
-from yt.utilities.on_demand_imports import \
-    _h5py, \
-    _astropy
 
 # Valid instruments
 valid_instruments = \
@@ -745,7 +745,6 @@ class SpectrumGenerator(AbsorptionSpectrum):
         else:
             mylog.info("Applying specified line spread function.")
             lsf = LSF(function=function, width=width, filename=filename)
-        from astropy.convolution import convolve
         self.flux_field = convolve(self.flux_field, lsf.kernel)
 
         # Negative fluxes don't make sense, so clip
@@ -1102,12 +1101,11 @@ def load_spectrum(filename, format='auto', instrument=None, lsf_kernel=None,
         else:
             format = 'ascii'
     if format == 'hdf5':
-        f = _h5py.File(filename, 'r')
+        f = h5py.File(filename, 'r')
         lambda_field = f['wavelength'][()]
         flux_field = f['flux'][()]
         tau_field = f['tau'][()]
     elif format == 'fits':
-        pyfits = _astropy.pyfits
         hdulist = pyfits.open(filename)
         data = hdulist[1].data
         lambda_field = data['wavelength']


### PR DESCRIPTION
This fixes a few test issues that have come up recently.
1. The sphinx doc language must now be set to something that is not None.
2. Remove some on-demand imports for packages that we require for installation.

This should fix two of the three errors in PR #9.