### PR TITLE
Add list of gold standard changesets.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
             echo 'TRIDENT_CONFIG=$HOME/.trident/config.tri' >> $BASH_ENV
             echo 'YT_GOLD=785befaaf016c6ce5238366092b3942b8d8c6760' >> $BASH_ENV
             echo 'YT_HEAD=main' >> $BASH_ENV
-            echo 'TRIDENT_GOLD=test-standard-v9' >> $BASH_ENV
+            echo 'TRIDENT_GOLD=61f5b11d471d242cc07135962a1386e56a19e3fd' >> $BASH_ENV
             echo 'TRIDENT_HEAD=tip' >> $BASH_ENV
 
   install-dependencies:
@@ -240,14 +240,14 @@ jobs:
 
       - restore_cache:
           name: "Restore answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-Zuverink
+          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-Zupo
 
       - run-tests:
           generate: 1
 
       - save_cache:
           name: "Save answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-Zuverink
+          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-Zupo
           paths:
             - ~/answer_test_data/test_results
 

--- a/tests/gold_standards.txt
+++ b/tests/gold_standards.txt
@@ -1,0 +1,3 @@
+# This is a record of gold standard versions since switching from a
+# tag to a changeset.
+July 5, 2023: 61f5b11d471d242cc07135962a1386e56a19e3fd


### PR DESCRIPTION
This changes slightly how we keep track of the testing gold standard. Previously, we used git tags, but those are mutable. Now, we will use changesets and store a file that lists them.